### PR TITLE
Add suggests for BiocGenerics and RUnit

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -23,7 +23,7 @@ Description: This package provides methods to identify active
         transcriptional network including co-regulation information.
 License: GPL-3
 Depends: R (>= 2.14), igraph, shiny, arules, methods
-Suggests: RColorBrewer, gplots, BiocStyle, knitr, rmarkdown
+Suggests: RColorBrewer, gplots, BiocGenerics, BiocStyle, knitr, rmarkdown, RUnit
 VignetteBuilder: knitr
 biocViews: NetworkInference, NetworkEnrichment, GeneRegulation,
         GeneExpression, GraphAndNetwork,SystemsBiology, Network,


### PR DESCRIPTION
Since Bioconductor 3.18 all dependencies should be explicitly declared. Transitive dependencies are not resolved anymore.

Fixes a `R CMD check` [failure](https://bioconductor.org/checkResults/3.18/bioc-LATEST/CoRegNet/nebbiolo2-checksrc.html) for Linux:
```
* checking tests ...
  Running ‘runTests.R’
 ERROR
Running the tests in ‘tests/runTests.R’ failed.
Last 13 lines of output:
  Loading required package: shiny
  Loading required package: arules
  Loading required package: Matrix
  
  Attaching package: 'arules'
  
  The following objects are masked from 'package:base':
  
      abbreviate, write
  
  [1] TRUE
  > BiocGenerics:::testPackage('CoRegNet')
  Error in loadNamespace(x) : there is no package called 'BiocGenerics'
  Calls: loadNamespace -> withRestarts -> withOneRestart -> doWithOneRestart
  Execution halted
```